### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@book000/pixivts": "0.46.48",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
-    "axios": "1.15.0",
+
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       eslint:
         specifier: 10.2.0
         version: 10.2.0
@@ -937,9 +934,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3927,14 +3921,6 @@ snapshots:
   aws-ssl-profiles@1.1.2: {}
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import { Discord, DiscordEmbed, Logger } from '@book000/node-utils'
 import { BookmarkRestrict, Pixiv } from '@book000/pixivts'
 import { Notified } from './notified'
 
-
 function isJSON(value: string): boolean {
   try {
     JSON.parse(value)
@@ -82,9 +81,9 @@ async function getImageArrayBuffer(url: string): Promise<ArrayBuffer> {
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36',
       Referer: 'https://www.pixiv.net/',
     },
-  });
-  if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
-  const data = await res.arrayBuffer();
+  })
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+  const data = await res.arrayBuffer()
   return data
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { Discord, DiscordEmbed, Logger } from '@book000/node-utils'
 import { BookmarkRestrict, Pixiv } from '@book000/pixivts'
 import { Notified } from './notified'
-import axios from 'axios'
+
 
 function isJSON(value: string): boolean {
   try {
@@ -76,15 +76,15 @@ async function getPixiv() {
 }
 
 async function getImageArrayBuffer(url: string): Promise<ArrayBuffer> {
-  const { data } = await axios.get<ArrayBuffer>(url, {
+  const res = await fetch(url, {
     headers: {
       'User-Agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36',
       Referer: 'https://www.pixiv.net/',
     },
-    responseType: 'arraybuffer',
-  })
-
+  });
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
+  const data = await res.arrayBuffer();
   return data
 }
 


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加