### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prefer-offline
 
 ENV NODE_ENV=production
 ENV NOTIFIED_FILE=/data/notified.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -23,8 +22,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 ENV NOTIFIED_FILE=/data/notified.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:24-alpine
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
-# pnpm v11 では TTY なし環境での node_modules 削除確認を回避するために CI=true が必要
-ENV CI=true
 
 # hadolint ignore=DL3018
 RUN apk update && \
@@ -17,14 +15,14 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prefer-offline
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 ENV NOTIFIED_FILE=/data/notified.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:24-alpine
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
+# pnpm v11 では TTY なし環境での node_modules 削除確認を回避するために CI=true が必要
+ENV CI=true
 
 # hadolint ignore=DL3018
 RUN apk update && \

--- a/package.json
+++ b/package.json
@@ -66,10 +66,5 @@
       "**/*.test.ts"
     ]
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる
- `[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY]`: Docker ビルド環境でインタラクティブな `pnpm approve-builds` が失敗

### 修正

1. `pnpm-workspace.yaml` を新規作成し、必要なビルドスクリプトを明示的に許可:
   - `esbuild: true`
   - `unrs-resolver: true`
2. `Dockerfile` から `pnpm approve-builds` の呼び出しを削除（`allowBuilds` 設定で代替）

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)