### PR TITLE
fix: TypeScript v6 対応のため tsconfig を更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "Node",
-    "lib": ["ESNext", "esnext.AsyncIterable"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,10 +23,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
+    "isolatedModules": true,
     "newLine": "LF",
+    "types": ["node", "jest"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

Renovate PR #1767 (`chore(deps): update dependency typescript to v6`) が CI で失敗しているため、`tsconfig.json` を TypeScript v6 に対応した設定に更新します。

## 変更内容

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `module: "commonjs"` | `module: "nodenext"` | TypeScript v6 で `node` / `Node` 系が非推奨 |
| `moduleResolution: "Node"` | `moduleResolution: "nodenext"` | 同上（TS5107 エラー対応） |
| `lib: ["ESNext", "esnext.AsyncIterable"]` | `lib: ["ESNext", "ESNext.AsyncIterable", "DOM"]` | `DOM` 追加で `fetch` / `console` などの型を解決 |
| `rootDir` 未設定 | `rootDir: "./src"` | TypeScript v6 でデフォルト値が `.` に変更されたため明示（TS5011 エラー対応） |
| `types` 未設定（全自動インクルード） | `types: ["node", "jest"]` | TypeScript v6 で `@types/*` 自動インクルードが廃止（TS6 breaking change 対応） |
| `baseUrl: "."` | 削除 | TypeScript v6 で非推奨（TS5101 エラー対応） |
| `paths: { "@/*": ["src/*"] }` | `paths: { "@/*": ["./src/*"] }` | `baseUrl` 削除に伴い絶対パスプレフィックスに変更 |
| `isolatedModules` 未設定 | `isolatedModules: true` | `module: nodenext` + ts-jest の互換性確保（TS151002 警告対応） |

## 対応した TypeScript v6 エラー

- `TS5107`: `'moduleResolution=node10' is deprecated` → `moduleResolution` を `nodenext` に移行
- `TS5101`: `'baseUrl' is deprecated` → `baseUrl` を削除
- `TS5011`: `'rootDir' must be explicitly set` → `rootDir: "./src"` を追加

## 互換性確認

- TypeScript v5.9.3（現在のデフォルトブランチ）: コンパイルエラーなし ✅
- TypeScript v6.0.3（Renovate PR 対象）: コンパイルエラーなし ✅
- Jest（ts-jest 29.x）: 正常動作 ✅

## 注意事項

- Renovate PR #1767 には直接触れていません
- このPRがマージされた後、Renovate PR #1767 が自動的にリベースされ CI を通過することを期待します