### PR TITLE
fix(deps): @book000/pixivts 0.61.2 の API 変更に追随する

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@book000/eslint-config": "1.15.8",
     "@book000/node-utils": "1.24.274",
-    "@book000/pixivts": "0.52.1",
+    "@book000/pixivts": "0.61.2",
     "@types/jest": "30.0.0",
     "@types/node": "24.13.3",
     "eslint": "10.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.24.274
         version: 1.24.274
       '@book000/pixivts':
-        specifier: 0.52.1
-        version: 0.52.1(@types/node@24.13.3)(typescript@6.0.3)
+        specifier: 0.61.2
+        version: 0.61.2
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -235,8 +235,8 @@ packages:
   '@book000/node-utils@1.24.274':
     resolution: {integrity: sha512-GLt0OOcYjShe89Nfxa4H8PqKEjlK2ET3dqWxMrYd3l0UhHdlDL0ZK5vzd7RTGY22Ecz6ZUdC7DdC/ldd36s+MA==}
 
-  '@book000/pixivts@0.52.1':
-    resolution: {integrity: sha512-SR928CwJyvzUu5tHkUPt5OmFoN4f5hJNKb2UKLD8vhMySfYotX69mqEylE8ibirJFnHgLX4DM03lsqUb5M+veg==}
+  '@book000/pixivts@0.61.2':
+    resolution: {integrity: sha512-7Qz7MBIK6wBoNzEjyHDwjZ2L2iGaig/mOBGzjNpA4jj28g+aD4WF8TYPyyNcAbeJm+WVWujt8nhYAaCXUYMMCA==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -602,9 +602,6 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
-  '@sqltools/formatter@1.2.5':
-    resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
-
   '@stylistic/eslint-plugin@2.11.0':
     resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -650,14 +647,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
-
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -931,10 +922,6 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  ansis@4.3.1:
-    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
-    engines: {node: '>=14'}
-
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -984,10 +971,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  aws-ssl-profiles@1.1.2:
-    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
-    engines: {node: '>= 6.0.0'}
 
   babel-jest@30.4.1:
     resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
@@ -1116,10 +1099,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1179,9 +1158,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
-
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1221,10 +1197,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
 
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
@@ -1576,9 +1548,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  generate-function@2.3.1:
-    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
-
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -1691,10 +1660,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  iconv-lite@0.7.3:
-    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
-    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1810,9 +1775,6 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
-
-  is-property@1.0.2:
-    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2102,9 +2064,6 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2114,10 +2073,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru.min@1.1.4:
-    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
-    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2166,16 +2121,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mysql2@3.22.5:
-    resolution: {integrity: sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==}
-    engines: {node: '>= 8.0'}
-    peerDependencies:
-      '@types/node': '>= 8'
-
-  named-placeholders@1.1.6:
-    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
-    engines: {node: '>=8.0.0'}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -2384,10 +2329,6 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2400,9 +2341,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  reflect-metadata@0.2.2:
-    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2459,9 +2397,6 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2527,11 +2462,6 @@ packages:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
 
-  snake-camel-types@1.0.1:
-    resolution: {integrity: sha512-nSX22RtPLtnpL3u6tql7SzUWN64q6eWXSkufbV8uRIBrAF4Z9VFtv8jvFqf0bVJaMXt+AEE6yI8k1fF/h1j8ZQ==}
-    peerDependencies:
-      typescript: '>=4.1'
-
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -2541,14 +2471,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  sql-escaper@1.3.3:
-    resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
-    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
-
-  sql-highlight@6.1.0:
-    resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
-    engines: {node: '>=14'}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -2750,63 +2672,6 @@ packages:
     resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
 
-  typeorm-naming-strategies@4.1.0:
-    resolution: {integrity: sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==}
-    peerDependencies:
-      typeorm: ^0.2.0 || ^0.3.0
-
-  typeorm@1.0.0:
-    resolution: {integrity: sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24.11.0}
-    hasBin: true
-    peerDependencies:
-      '@google-cloud/spanner': ^8.0.0
-      '@sap/hana-client': ^2.14.22
-      better-sqlite3: ^12.0.0
-      ioredis: ^5.0.4
-      mongodb: ^7.0.0
-      mssql: ^12.0.0
-      mysql2: ^3.15.3
-      oracledb: ^6.3.0
-      pg: ^8.5.1
-      pg-native: ^3.0.0
-      pg-query-stream: ^4.0.0
-      redis: ^5.0.0
-      sql.js: ^1.4.0
-      ts-node: ^10.9.2
-      typeorm-aurora-data-api-driver: ^3.0.0
-    peerDependenciesMeta:
-      '@google-cloud/spanner':
-        optional: true
-      '@sap/hana-client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      ioredis:
-        optional: true
-      mongodb:
-        optional: true
-      mssql:
-        optional: true
-      mysql2:
-        optional: true
-      oracledb:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      pg-query-stream:
-        optional: true
-      redis:
-        optional: true
-      sql.js:
-        optional: true
-      ts-node:
-        optional: true
-      typeorm-aurora-data-api-driver:
-        optional: true
-
   typescript-eslint@8.61.1:
     resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2907,10 +2772,6 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2929,17 +2790,9 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3165,33 +3018,7 @@ snapshots:
       winston: 3.19.0
       winston-daily-rotate-file: 5.0.0(winston@3.19.0)
 
-  '@book000/pixivts@0.52.1(@types/node@24.13.3)(typescript@6.0.3)':
-    dependencies:
-      '@types/qs': 6.15.1
-      mysql2: 3.22.5(@types/node@24.13.3)
-      qs: 6.15.2
-      snake-camel-types: 1.0.1(typescript@6.0.3)
-      typeorm: 1.0.0(mysql2@3.22.5(@types/node@24.13.3))
-      typeorm-naming-strategies: 4.1.0(typeorm@1.0.0(mysql2@3.22.5(@types/node@24.13.3)))
-    transitivePeerDependencies:
-      - '@google-cloud/spanner'
-      - '@sap/hana-client'
-      - '@types/node'
-      - babel-plugin-macros
-      - better-sqlite3
-      - ioredis
-      - mongodb
-      - mssql
-      - oracledb
-      - pg
-      - pg-native
-      - pg-query-stream
-      - redis
-      - sql.js
-      - supports-color
-      - ts-node
-      - typeorm-aurora-data-api-driver
-      - typescript
+  '@book000/pixivts@0.61.2': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -3449,7 +3276,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -3536,7 +3363,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3587,8 +3414,6 @@ snapshots:
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
-
-  '@sqltools/formatter@1.2.5': {}
 
   '@stylistic/eslint-plugin@2.11.0(eslint@10.6.0)(typescript@6.0.3)':
     dependencies:
@@ -3651,15 +3476,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@24.13.2':
-    dependencies:
-      undici-types: 7.18.2
-
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/qs@6.15.1': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -3918,8 +3737,6 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  ansis@4.3.1: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -4003,8 +3820,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  aws-ssl-profiles@1.1.2: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -4150,12 +3965,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -4215,8 +4024,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dayjs@1.11.21: {}
-
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -4242,8 +4049,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  denque@2.1.0: {}
 
   detect-indent@7.0.2: {}
 
@@ -4754,10 +4559,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  generate-function@2.3.1:
-    dependencies:
-      is-property: 1.0.2
-
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -4870,10 +4671,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  iconv-lite@0.7.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4982,8 +4779,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-
-  is-property@1.0.2: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5194,7 +4989,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5344,7 +5139,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -5372,7 +5167,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 24.13.3
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.4.1
       merge-stream: 2.0.0
@@ -5466,8 +5261,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
-  long@5.3.2: {}
-
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5477,8 +5270,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru.min@1.1.4: {}
 
   make-dir@4.0.0:
     dependencies:
@@ -5519,22 +5310,6 @@ snapshots:
   moment@2.30.1: {}
 
   ms@2.1.3: {}
-
-  mysql2@3.22.5(@types/node@24.13.3):
-    dependencies:
-      '@types/node': 24.13.3
-      aws-ssl-profiles: 1.1.2
-      denque: 2.1.0
-      generate-function: 2.3.1
-      iconv-lite: 0.7.3
-      long: 5.3.2
-      lru.min: 1.1.4
-      named-placeholders: 1.1.6
-      sql-escaper: 1.3.3
-
-  named-placeholders@1.1.6:
-    dependencies:
-      lru.min: 1.1.4
 
   napi-postinstall@0.3.4: {}
 
@@ -5740,10 +5515,6 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.1
-
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
@@ -5755,8 +5526,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5839,8 +5608,6 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  safer-buffer@2.1.2: {}
-
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -5914,10 +5681,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
-  snake-camel-types@1.0.1(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
-
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -5926,10 +5689,6 @@ snapshots:
   source-map@0.6.1: {}
 
   sprintf-js@1.0.3: {}
-
-  sql-escaper@1.3.3: {}
-
-  sql-highlight@6.1.0: {}
 
   stack-trace@0.0.10: {}
 
@@ -6103,7 +5862,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.23.0:
     dependencies:
@@ -6153,28 +5913,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typeorm-naming-strategies@4.1.0(typeorm@1.0.0(mysql2@3.22.5(@types/node@24.13.3))):
-    dependencies:
-      typeorm: 1.0.0(mysql2@3.22.5(@types/node@24.13.3))
-
-  typeorm@1.0.0(mysql2@3.22.5(@types/node@24.13.3)):
-    dependencies:
-      '@sqltools/formatter': 1.2.5
-      ansis: 4.3.1
-      dayjs: 1.11.21
-      debug: 4.4.3
-      dedent: 1.7.2
-      reflect-metadata: 0.2.2
-      sql-highlight: 6.1.0
-      tinyglobby: 0.2.17
-      tslib: 2.8.1
-      yargs: 18.0.0
-    optionalDependencies:
-      mysql2: 3.22.5(@types/node@24.13.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   typescript-eslint@8.61.1(eslint@10.6.0)(typescript@6.0.3):
     dependencies:
@@ -6341,12 +6079,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
 
   write-file-atomic@5.0.1:
@@ -6360,8 +6092,6 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs-parser@22.0.0: {}
-
   yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
@@ -6371,15 +6101,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import { Discord, DiscordEmbed, Logger } from '@book000/node-utils'
-import { BookmarkRestrict, Pixiv } from '@book000/pixivts'
+import { BookmarkRestrict, PixivClient } from '@book000/pixivts'
 import { Notified } from './notified'
 
 function isJSON(value: string): boolean {
@@ -51,23 +51,16 @@ async function getPixiv() {
     return
   }
 
-  const isEnabledResponseSave = !!process.env.RESPONSE_DB_HOSTNAME
-  const pixiv = await Pixiv.of(inputRefreshToken, {
-    debugOptions: {
-      outputResponse: {
-        enable: isEnabledResponseSave,
-      },
-    },
-  })
+  const pixiv = await PixivClient.of(inputRefreshToken)
 
   fs.writeFileSync(
     tokenPath,
     JSON.stringify({
-      access_token: pixiv.accessToken,
+      access_token: pixiv.getAccessToken(),
       user: {
         id: pixiv.userId,
       },
-      refresh_token: pixiv.refreshToken,
+      refresh_token: pixiv.getRefreshToken(),
     })
   )
 
@@ -87,65 +80,65 @@ async function getImageArrayBuffer(url: string): Promise<ArrayBuffer> {
   return data
 }
 
-async function getIllusts(pixiv: Pixiv, targetUserId: number) {
+async function getIllusts(pixiv: PixivClient, targetUserId: number) {
   const logger = Logger.configure('getIllusts')
 
-  const bookmarkPublicIllusts = await pixiv.userBookmarksIllust({
+  const bookmarkPublicIllusts = await pixiv.users.bookmarks.illusts({
     userId: targetUserId,
     restrict: BookmarkRestrict.PUBLIC,
   })
-  if (bookmarkPublicIllusts.status !== 200) {
+  if (bookmarkPublicIllusts.isErr) {
     logger.error(
-      `🚨 Failed to get illust private bookmarks: ${bookmarkPublicIllusts.status} ${JSON.stringify(bookmarkPublicIllusts.data)}`
+      `🚨 Failed to get illust private bookmarks: ${JSON.stringify(bookmarkPublicIllusts.error)}`
     )
     return
   }
 
-  const bookmarkPrivateIllusts = await pixiv.userBookmarksIllust({
+  const bookmarkPrivateIllusts = await pixiv.users.bookmarks.illusts({
     userId: targetUserId,
     restrict: BookmarkRestrict.PRIVATE,
   })
-  if (bookmarkPrivateIllusts.status !== 200) {
+  if (bookmarkPrivateIllusts.isErr) {
     logger.error(
-      `🚨 Failed to get illust private bookmarks: ${bookmarkPrivateIllusts.status} ${JSON.stringify(bookmarkPrivateIllusts.data)}`
+      `🚨 Failed to get illust private bookmarks: ${JSON.stringify(bookmarkPrivateIllusts.error)}`
     )
     return
   }
 
   return [
-    ...bookmarkPublicIllusts.data.illusts.toReversed(),
-    ...bookmarkPrivateIllusts.data.illusts.toReversed(),
+    ...bookmarkPublicIllusts.value.illusts.toReversed(),
+    ...bookmarkPrivateIllusts.value.illusts.toReversed(),
   ]
 }
 
-async function getNovels(pixiv: Pixiv, targetUserId: number) {
+async function getNovels(pixiv: PixivClient, targetUserId: number) {
   const logger = Logger.configure('getNovels')
 
-  const bookmarkPublicNovels = await pixiv.userBookmarksNovel({
+  const bookmarkPublicNovels = await pixiv.users.bookmarks.novels({
     userId: targetUserId,
     restrict: BookmarkRestrict.PUBLIC,
   })
-  if (bookmarkPublicNovels.status !== 200) {
+  if (bookmarkPublicNovels.isErr) {
     logger.error(
-      `🚨 Failed to get novel public bookmarks: ${bookmarkPublicNovels.status} ${JSON.stringify(bookmarkPublicNovels.data)}`
+      `🚨 Failed to get novel public bookmarks: ${JSON.stringify(bookmarkPublicNovels.error)}`
     )
     return
   }
 
-  const bookmarkPrivateNovels = await pixiv.userBookmarksNovel({
+  const bookmarkPrivateNovels = await pixiv.users.bookmarks.novels({
     userId: targetUserId,
     restrict: BookmarkRestrict.PRIVATE,
   })
-  if (bookmarkPrivateNovels.status !== 200) {
+  if (bookmarkPrivateNovels.isErr) {
     logger.error(
-      `🚨 Failed to get novel private bookmarks: ${bookmarkPrivateNovels.status} ${JSON.stringify(bookmarkPrivateNovels.data)}`
+      `🚨 Failed to get novel private bookmarks: ${JSON.stringify(bookmarkPrivateNovels.error)}`
     )
     return
   }
 
   return [
-    ...bookmarkPublicNovels.data.novels.toReversed(),
-    ...bookmarkPrivateNovels.data.novels.toReversed(),
+    ...bookmarkPublicNovels.value.novels.toReversed(),
+    ...bookmarkPrivateNovels.value.novels.toReversed(),
   ]
 }
 function pad(n: number) {
@@ -166,7 +159,7 @@ function formatDateTime(date: Date) {
 }
 
 async function processIllusts(
-  pixiv: Pixiv,
+  pixiv: PixivClient,
   discord: Discord,
   isFirst: boolean
 ) {
@@ -197,11 +190,11 @@ async function processIllusts(
       title,
       caption: captionRaw,
       user: { name: username, id: userId },
-      total_bookmarks: totalBookmarks,
-      total_view: totalView,
-      image_urls: { large: imageUrl },
+      totalBookmarks,
+      totalView,
+      imageUrls: { large: imageUrl },
       tags: tagLists,
-      create_date: createDateRaw,
+      createDate: createDateRaw,
     } = illust
 
     const caption = captionRaw.replaceAll(/<("[^"]*"|'[^']*'|[^"'>])*>/g, '')
@@ -269,7 +262,11 @@ async function processIllusts(
   }
 }
 
-async function processNovels(pixiv: Pixiv, discord: Discord, isFirst: boolean) {
+async function processNovels(
+  pixiv: PixivClient,
+  discord: Discord,
+  isFirst: boolean
+) {
   const logger = Logger.configure('processNovels')
 
   const targetUserId = Number(process.env.PIXIV_USER_ID)
@@ -298,9 +295,9 @@ async function processNovels(pixiv: Pixiv, discord: Discord, isFirst: boolean) {
       caption: captionRaw,
       user: { name: username, id: userId },
       tags: tagLists,
-      total_bookmarks: totalBookmarks,
-      total_view: totalView,
-      create_date: createDateRaw,
+      totalBookmarks,
+      totalView,
+      createDate: createDateRaw,
     } = novel
 
     const caption = captionRaw.replaceAll(/<("[^"]*"|'[^']*'|[^"'>])*>/g, '')
@@ -389,12 +386,8 @@ async function main() {
     return
   }
 
-  try {
-    await processIllusts(pixiv, discord, isFirst)
-    await processNovels(pixiv, discord, isFirst)
-  } finally {
-    await pixiv.close()
-  }
+  await processIllusts(pixiv, discord, isFirst)
+  await processNovels(pixiv, discord, isFirst)
 }
 
 ;(async () => {


### PR DESCRIPTION
## 概要
#1966 (`@book000/pixivts` 0.52.1 → 0.61.2 の Renovate PR) が Node CI (ESLint/tsc) で失敗していた原因を修正します。

## 原因
0.60.0 で pixivts 側の API が破壊的に再設計されており、以下の変更に本リポジトリの呼び出し側が追随できていませんでした。

- `Pixiv` クラスが `PixivClient` に改名され、`users.bookmarks.illusts` / `users.bookmarks.novels` の名前空間 API に変更
- レスポンス形式が `{ status, data }` から `Result` 型 (`isOk`/`isErr`/`value`/`error`) に変更
- `PixivIllustItem` / `PixivNovelItem` のフィールドが snake_case から lowerCamelCase (`total_bookmarks` → `totalBookmarks` 等) に変更
- `PixivClient` に `close()` / `accessToken` / `refreshToken` プロパティが存在しなくなり、`getAccessToken()` / `getRefreshToken()` に変更

## 対応
- 上記 API 変更に呼び出し箇所を追随
- `debugOptions.outputResponse`（`RESPONSE_DB_HOSTNAME` 環境変数で制御していたレスポンス保存機能）はコア側から `@book000/pixivts-db-mysql` パッケージの `onResponse` インターセプタ方式に分離されました。本リポジトリでは同パッケージを導入しておらず、README / compose.yaml 等にも `RESPONSE_DB_HOSTNAME` の記載がなく未使用の設定だったため、機能ごと削除しました（新パッケージ導入は本修正のスコープ外と判断）

## 確認
- `pnpm lint`（tsc / eslint / prettier）がすべて成功
- `pnpm test`（テストファイルなし、`--passWithNoTests` で成功）

関連: #1966