### PR TITLE
chore: worktree 作成時に含めるファイルを指定する .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/token.json
+data/notified.json
+data/


### PR DESCRIPTION
## 概要

`git worktree add` 実行時に自動でコピーされるファイルを指定する `.worktreeinclude` を追加しました。

## 追加したパターン

- `data/token.json`
- `data/notified.json`
- `data/`

## 根拠

- `.gitignore` に `data/` がそのまま記載されており、ローカルの `data` ディレクトリ全体が Git 管理外になっている。
- `src/main.ts` では `process.env.PIXIV_TOKEN_PATH ?? 'data/token.json'` から pixiv のリフレッシュトークンを読み込んでいる。
- `src/notified.ts` では `process.env.NOTIFIED_FILE ?? 'data/notified.json'` を使って通知済みアイテムを永続化している。
- README には `data/token.json` にリフレッシュトークンを記載する手順が明記されている。
- `data/token.json` はサードパーティの Selenium スクリプトで取得する必要があり、再生成が容易ではないため、worktree 作成のたびに手動で用意し直すのは負担が大きい。
- `.env` 系のファイルは存在せず、Discord/pixiv 関連のシークレットは環境変数経由で供給されている。

## 関連 Issue

https://github.com/book000/book000/issues/132
